### PR TITLE
Bug/fix rcon command for skip match

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -261,7 +261,7 @@ class moderation(commands.Cog):
             if instance_details.game == 'squad':
                 res = inst.rcon.change_layer(map_name)
             else:
-                res = inst.rcon.set_next_map(map_name)
+                res = inst.rcon.switch_to_map(map_name)
         else:
             res = inst.rcon.end_match()
 


### PR DESCRIPTION
Notched that when doing previous changes for set next layer and change current layer for squad. I had set the wrong rcon command for if the game was not squad when skipping match - it was using setnextmap instead